### PR TITLE
avoid cpu waste on connection storm

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -97,9 +97,9 @@ protected-mode yes
 # If port 0 is specified Redis will not listen on a TCP socket.
 port 6379
 
-# Accept connections from ctrip monitor on the specified port, default is 0 (disable).
+# Accept connections from ctrip monitor on the specified port, default is 6380, set 0 to disable
 # The specified port keep working even if clients overflow.
-ctrip-monitor-port 0
+ctrip-monitor-port 6380
 
 # TCP listen() backlog.
 #

--- a/redis.conf
+++ b/redis.conf
@@ -97,6 +97,10 @@ protected-mode yes
 # If port 0 is specified Redis will not listen on a TCP socket.
 port 6379
 
+# Accept connections from ctrip monitor on the specified port, default is 0 (disable).
+# The specified port keep working even if clients overflow.
+ctrip-monitor-port 0
+
 # TCP listen() backlog.
 #
 # In high requests-per-second environments you need a high backlog in order

--- a/src/config.c
+++ b/src/config.c
@@ -2570,6 +2570,7 @@ standardConfig configs[] = {
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
+    createIntConfig("ctrip-monitor-port", NULL, IMMUTABLE_CONFIG, 0, 65535, server.ctrip_monitor_port, 0, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
     createIntConfig("io-threads", NULL, IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */

--- a/src/config.c
+++ b/src/config.c
@@ -2570,7 +2570,7 @@ standardConfig configs[] = {
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
-    createIntConfig("ctrip-monitor-port", NULL, IMMUTABLE_CONFIG, 0, 65535, server.ctrip_monitor_port, 0, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
+    createIntConfig("ctrip-monitor-port", NULL, IMMUTABLE_CONFIG, 0, 65535, server.ctrip_monitor_port, 6380, INTEGER_CONFIG, NULL, NULL), /* Monitor TCP port. */
     createIntConfig("io-threads", NULL, IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */

--- a/src/server.h
+++ b/src/server.h
@@ -289,6 +289,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
                                           RDB without replication buffer. */
 #define CLIENT_SWAPPING (1ULL<<43) /* The client is waiting swap. */
 #define CLIENT_SWAP_UNLOCKING (1ULL<<44) /* Client is releasing swap lock. */
+#define CLIENT_CTRIP_MONITOR (1ULL<<45) /* Client for ctrip monitor. */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */
@@ -1708,6 +1709,11 @@ struct redisServer {
     int target_replica_port; /* Failover target port */
     int failover_state; /* Failover state */
 
+    /* accept ignore */
+    int ctrip_ignore_accept;
+    int ctrip_monitor_port;
+    int ctrip_monitorfd;
+
     int swap_mode;      /* Swap mode: memory/swap/disk */
 		/* rocksdb engine */
     int rocksdb_epoch;
@@ -2483,6 +2489,12 @@ robj *activeDefragStringOb(robj* ob, long *defragged);
 #define RESTART_SERVER_GRACEFULLY (1<<0)     /* Do proper shutdown. */
 #define RESTART_SERVER_CONFIG_REWRITE (1<<1) /* CONFIG REWRITE before restart.*/
 int restartServer(int flags, mstime_t delay);
+
+/* accept ignore */
+void ctrip_ignoreAcceptEvent();
+void ctrip_resetAcceptIgnore();
+void ctrip_initMonitorPort();
+void acceptMonitorHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 
 /* Set data type */
 robj *setTypeCreate(sds value);

--- a/tests/ctrip/monitor.tcl
+++ b/tests/ctrip/monitor.tcl
@@ -1,0 +1,42 @@
+set mport [find_available_port $::baseport $::portcount]
+start_server [list overrides [list ctrip-monitor-port $mport] tags "ctrip_monitor"] {
+    set redis_host [srv 0 host]
+    set redis_port [srv 0 port]
+
+    test {ignore accept after clients overflow} {
+        r config set maxclients 1
+
+        # trigger overflow
+        set r2 [redis $redis_host $redis_port 0 0]
+        catch {$r2 ping} error
+        assert_match $error "ERR max number of clients reached"
+        after 100
+
+        # read timeout for clients overflow
+        set s [socket $redis_host $redis_port]
+        fconfigure $s -blocking 0
+        puts $s ping
+        flush $s
+        after 100
+        assert_match [read -nonewline $s] {}
+
+        r config set maxclients 1000
+        after 100
+        assert_match [read -nonewline $s] +PONG
+    }
+
+    test {monitor port work when clients overflow} {
+        r config set maxclients 1
+        set r2 [redis $redis_host $redis_port 0 0]
+        catch {$r2 ping} error
+        assert_match $error "ERR max number of clients reached"
+
+        set m [redis $redis_host $mport 0 0]
+        assert_match [$m ping] "PONG"
+
+        $m config set maxclients 1000
+        set r3 [redis $redis_host $redis_port 0 0]
+        assert_match [$r3 ping] "PONG"
+    }
+
+}

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -395,13 +395,16 @@ proc start_server {options {code undefined}} {
 
     # start every server on a different port
     set port [find_available_port $::baseport $::portcount]
+    set monitor_port [find_available_port $::baseport $::portcount]
     if {$::tls} {
         dict set config "port" 0
         dict set config "tls-port" $port
+        dict set config "ctrip-monitor-port" $monitor_port
         dict set config "tls-cluster" "yes"
         dict set config "tls-replication" "yes"
     } else {
         dict set config port $port
+        dict set config "ctrip-monitor-port" $monitor_port
     }
 
     set unixsocket [file normalize [format "%s/%s" [dict get $config "dir"] "socket"]]

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -69,6 +69,7 @@ set ::disk_tests {
     ctrip/gtid
     ctrip/sync-gtid
     ctrip/replication-psync-gtid
+    ctrip/monitor
     unit/printver
     unit/dump
     unit/auth
@@ -115,6 +116,7 @@ set ::all_tests {
     ctrip/gtid
     ctrip/sync-gtid
     ctrip/replication-psync-gtid
+    ctrip/monitor
     unit/shutdown
     unit/printver
     unit/dump

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -207,6 +207,7 @@ start_server {tags {"introspection"}} {
             rocksdb.data.max_bytes_for_level_base
             rocksdb.meta.max_bytes_for_level_base
             swap-scan-session-bits
+            ctrip-monitor-port
         }
 
         if {!$::tls} {


### PR DESCRIPTION
1. ignore accept event on clients overflow
2. open specified port for monitor which can keep working even if clients overflow